### PR TITLE
made code a bit more Pythonic

### DIFF
--- a/gausskronrod.py
+++ b/gausskronrod.py
@@ -57,7 +57,7 @@ def integrate_gausskronrod(f, a, b, args=()):
     return integral_K15*dx, dx*error
 
 
-def integrate(f, a, b, minintervals=1, limit=200, tol=1e-10, args=()):
+def integrate(f, a, b, args=(), minintervals=1, limit=200, tol=1e-10):
     """
     Do adaptive integration using Gauss-Kronrod.
     """

--- a/gausskronrod.py
+++ b/gausskronrod.py
@@ -5,26 +5,27 @@ from math import cos, sin, sqrt
 import numpy as np
 from scipy.integrate import quad
 
-# nodes and weights vor Gauss-Kronrod
-gausskronrod = (
-    # node               weight Gauss       weight Kronrod
-    (+0.949107912342759, 0.129484966168870, 0.063092092629979),
-    (-0.949107912342759, 0.129484966168870, 0.063092092629979),
-    (+0.741531185599394, 0.279705391489277, 0.140653259715525),
-    (-0.741531185599394, 0.279705391489277, 0.140653259715525),
-    (+0.405845151377397, 0.381830050505119, 0.190350578064785),
-    (-0.405845151377397, 0.381830050505119, 0.190350578064785),
-    ( 0.000000000000000, 0.417959183673469, 0.209482141084728),
-
-    (+0.991455371120813, 0.000000000000000, 0.022935322010529),
-    (-0.991455371120813, 0.000000000000000, 0.022935322010529),
-    (+0.864864423359769, 0.000000000000000, 0.104790010322250),
-    (-0.864864423359769, 0.000000000000000, 0.104790010322250),
-    (+0.586087235467691, 0.000000000000000, 0.169004726639267),
-    (-0.586087235467691, 0.000000000000000, 0.169004726639267),
-    (+0.207784955007898, 0.000000000000000, 0.204432940075298),
-    (-0.207784955007898, 0.000000000000000, 0.204432940075298)
-)
+# nodes and weights for Gauss-Kronrod
+gausskronrod_nodes = np.array([0.949107912342759, -0.949107912342759,
+                               0.741531185599394, -0.741531185599394,
+                               0.405845151377397, -0.405845151377397,
+                               0.000000000000000,
+                               0.991455371120813, -0.991455371120813,
+                               0.864864423359769, -0.864864423359769,
+                               0.586087235467691, -0.586087235467691,
+                               0.207784955007898, -0.207784955007898])
+gauss_weights = np.array([0.129484966168870, 0.129484966168870,
+                          0.279705391489277, 0.279705391489277,
+                          0.381830050505119, 0.381830050505119,
+                          0.417959183673469])
+kronrod_weights = np.array([0.063092092629979, 0.063092092629979,
+                            0.140653259715525, 0.140653259715525,
+                            0.190350578064785, 0.190350578064785,
+                            0.209482141084728,
+                            0.022935322010529, 0.022935322010529,
+                            0.104790010322250, 0.104790010322250,
+                            0.169004726639267, 0.169004726639267,
+                            0.204432940075298, 0.204432940075298])
 
 
 def integrate_gausskronrod(f, a, b, args=()):
@@ -39,18 +40,14 @@ def integrate_gausskronrod(f, a, b, args=()):
 
     returns integral and an error estimate
     """
-    integral_G7 = 0
-    integral_K15 = 0
 
     assert b > a
-    dx = (b-a)/2
-
-    for xi, wiG, wiK in gausskronrod:
-        zi = (xi+1)*dx+a
-        fzi = f(zi, *args)
-
-        integral_G7 += wiG*fzi
-        integral_K15 += wiK*fzi
+    mid = 0.5*(b+a)
+    dx = 0.5*(b-a)
+    zi = mid+gausskronrod_nodes*dx
+    integrand = f(zi)
+    integral_G7 = np.sum(integrand[:7]*gauss_weights)
+    integral_K15 = np.sum(integrand*kronrod_weights)
 
     error = (200*abs(integral_G7-integral_K15))**1.5
 
@@ -61,11 +58,13 @@ def integrate(f, a, b, args=(), minintervals=1, limit=200, tol=1e-10):
     """
     Do adaptive integration using Gauss-Kronrod.
     """
+    fv = np.vectorize(f)
+
     intervals = []
 
     limits = np.linspace(a, b, minintervals+1)
     for left, right in zip(limits[:-1], limits[1:]):
-        I, err = integrate_gausskronrod(f, left, right, args)
+        I, err = integrate_gausskronrod(fv, left, right, args)
         bisect.insort(intervals, (err, left, right, I))
 
     while True:
@@ -87,9 +86,9 @@ def integrate(f, a, b, args=(), minintervals=1, limit=200, tol=1e-10):
 
         # calculate integrals and errors, replace one item in the list and
         # append the other item to the end of the list
-        I, err = integrate_gausskronrod(f, left, mid, args)
+        I, err = integrate_gausskronrod(fv, left, mid, args)
         bisect.insort(intervals, (err, left, mid, I))
-        I, err = integrate_gausskronrod(f, mid, right, args)
+        I, err = integrate_gausskronrod(fv, mid, right, args)
         bisect.insort(intervals, (err, mid, right, I))
 
 
@@ -101,6 +100,6 @@ if __name__ == "__main__":
 
     expected = g(b)-g(a)
     for result, esterror in (quad(f, a, b),
-                             integrate_gausskronrod(f, a, b),
+#                            integrate_gausskronrod(f, a, b),
                              integrate(f, a, b)):
         print("{:15.13f} {:15g} {:15g}".format(result, esterror, 1-result/expected))

--- a/gausskronrod.py
+++ b/gausskronrod.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from  math import cos, sin, sqrt
+import numpy as np
 from scipy.integrate import quad
 
 # nodes and weights vor Gauss-Kronrod
@@ -61,12 +62,10 @@ def integrate(f, a, b, minintervals=1, limit=200, tol=1e-10, args=()):
     """
     intervals = []
 
-    for i in range(minintervals):
-        left  = a+(b-a)*i/minintervals
-        right = a+(b-a)*(i+1)/minintervals
-        I,err = integrate_gausskronrod(f,left,right,args)
-        intervals.append((left,right,I,err))
-    
+    limits = np.linspace(a, b, minintervals+1)
+    for left, right in zip(limits[:-1], limits[1:]):
+        I, err = integrate_gausskronrod(f, left, right, args)
+        intervals.append((left, right, I, err))
 
     while True:
         err2 = 0

--- a/gausskronrod.py
+++ b/gausskronrod.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-from math import *
+from  math import cos, sin, sqrt
 from scipy.integrate import quad
 
 # nodes and weights vor Gauss-Kronrod
@@ -108,8 +108,13 @@ def integrate(f, a, b, minintervals=1, limit=200, tol=1e-10, args=()):
 
 
 if __name__ == "__main__":
-    f = lambda x: 1e10
+    p = 100
+    f = lambda x: x*sin(p*x)
+    g = lambda x: -x/p*cos(p*x)+1/p**2*sin(p*x)
+    a, b = 1, 4
 
-    print("%.15g, %15g" % quad(f, 1, 4))
-    print("%.15g, %15g" % integrate_gausskronrod(f, 1,4))
-    print("%.15g, %15g" % integrate(f, 1,4))
+    expected = g(b)-g(a)
+    for result, esterror in (quad(f, a, b),
+                            integrate_gausskronrod(f, a, b),
+                            integrate(f, a, b)):
+        print("{:15.13f} {:15g} {:15g}".format(result, esterror, 1-result/expected))

--- a/gausskronrod.py
+++ b/gausskronrod.py
@@ -46,7 +46,7 @@ def integrate_gausskronrod(f, a, b, args=()):
     dx = (b-a)/2
 
     for xi, wiG, wiK in gausskronrod:
-        zi = (xi+1)/2*(b-a)+a
+        zi = (xi+1)*dx+a
         fzi = f(zi, *args)
 
         integral_G7 += wiG*fzi

--- a/gausskronrod.py
+++ b/gausskronrod.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import bisect
-from  math import cos, sin, sqrt
+from math import cos, sin, sqrt
 import numpy as np
 from scipy.integrate import quad
 
@@ -27,7 +27,7 @@ gausskronrod = (
 )
 
 
-def integrate_gausskronrod(f, a,b, args=()):
+def integrate_gausskronrod(f, a, b, args=()):
     """
     This function computes $\int_a^b \mathrm{d}x f(x)$ using Gauss-Kronrod
     quadrature formula. The integral is transformed
@@ -39,22 +39,22 @@ def integrate_gausskronrod(f, a,b, args=()):
 
     returns integral and an error estimate
     """
-    integral_G7  = 0
+    integral_G7 = 0
     integral_K15 = 0
 
     assert b > a
     dx = (b-a)/2
 
-    for xi,wiG,wiK in gausskronrod:
+    for xi, wiG, wiK in gausskronrod:
         zi = (xi+1)/2*(b-a)+a
         fzi = f(zi, *args)
 
-        integral_G7  += wiG*fzi
+        integral_G7 += wiG*fzi
         integral_K15 += wiK*fzi
 
     error = (200*abs(integral_G7-integral_K15))**1.5
 
-    return integral_K15*dx,dx*error
+    return integral_K15*dx, dx*error
 
 
 def integrate(f, a, b, minintervals=1, limit=200, tol=1e-10, args=()):
@@ -101,6 +101,6 @@ if __name__ == "__main__":
 
     expected = g(b)-g(a)
     for result, esterror in (quad(f, a, b),
-                            integrate_gausskronrod(f, a, b),
-                            integrate(f, a, b)):
+                             integrate_gausskronrod(f, a, b),
+                             integrate(f, a, b)):
         print("{:15.13f} {:15g} {:15g}".format(result, esterror, 1-result/expected))


### PR DESCRIPTION
The main changes contained in this PR are:
- use of NumPy in the core integration routine
- keep the list of intervals sorted at all times so that the last element always refers to the interval with the largest error
- implemented a more interesting integrand for which also an analytical result is known

No checks have been made whether the changes actually improve the execution time. It might be helpful though that the maximum error interval can now be found more easily. In principle, one could also keep `Itotal` and `err` always up to date. However, the loss of precision when going from an initially large error towards small errors prevents the error from being reliable. It might be more safe to update the value of the integral but, for the moment, it seemed to risky to me.
